### PR TITLE
test_package build simple example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ db-wal
 db
 
 __pycache__
+*.pyc

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+project(SceltaTest)
+cmake_minimum_required(VERSION 2.8.12)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+ADD_EXECUTABLE(example example.cpp)
+TARGET_LINK_LIBRARIES(example ${CONAN_LIBS})
+

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -11,15 +11,9 @@ class HelloTestConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
-        os.chdir("../../../")
-
-        if not os.path.exists("build"):
-            os.mkdir("build")
-
-        os.chdir("build")
-        self.run("cmake .. %s" % cmake.command_line)
+        self.run('cmake "%s" %s' % (self.conanfile_directory, cmake.command_line))
         self.run("cmake --build . %s" % cmake.build_config)
-        self.run("make check -j8")
 
     def test(self):
-        ()
+        os.chdir("bin")
+        self.run(".%sexample" % os.sep)

--- a/test_package/example.cpp
+++ b/test_package/example.cpp
@@ -1,0 +1,15 @@
+#include "scelta.hpp"
+
+int main(){
+  
+  using shape = std::variant<circle, box>;
+
+  shape s0{circle{/*...*/}};
+  shape s1{box{/*...*/}};
+
+  // In place `match` visitation.
+  scelta::match([](circle, circle){ /* ... */ },
+                [](circle, box)   { /* ... */ },
+                [](box,    circle){ /* ... */ },
+                [](box,    box)   { /* ... */ })(s0, s1);
+}


### PR DESCRIPTION
Hi!

This would be the idea for the test_package, not to run the full test suite, that was done while creating the package, you don't want to build it twice, rather building an example application to ensure that the headers were correctly packaged.