### PR TITLE
One `match` to rule them all

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .clang-format
+buildcl
 html
 code_docs
 docs

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .clang-format
+buildgcc
 buildcl
 html
 code_docs

--- a/example/error_handling.cpp
+++ b/example/error_handling.cpp
@@ -49,7 +49,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    return scelta::match(
+    return scelta::experimental::recursive::match(
         [](const io_outcome::success& x) { std::cout << x._contents << std::endl;        return 0; },
         [](const io_outcome::not_found&) { std::cerr << "File not found\n" << std::endl; return 1; })
         (read_file(argv[1]));

--- a/example/error_handling.cpp
+++ b/example/error_handling.cpp
@@ -49,7 +49,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    return scelta::experimental::recursive::match(
+    return scelta::match(
         [](const io_outcome::success& x) { std::cout << x._contents << std::endl;        return 0; },
         [](const io_outcome::not_found&) { std::cerr << "File not found\n" << std::endl; return 1; })
         (read_file(argv[1]));

--- a/example/example_utils.hpp
+++ b/example/example_utils.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <scelta.hpp>
+#include <scelta/recursive/experimental_match.hpp>
 
 namespace example
 {

--- a/example/example_utils.hpp
+++ b/example/example_utils.hpp
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <scelta.hpp>
-#include <scelta/recursive/experimental_match.hpp>
+#include <scelta/match.hpp>
 
 namespace example
 {

--- a/example/expression.cpp
+++ b/example/expression.cpp
@@ -59,7 +59,7 @@ int main()
             const auto& op  = std::get<1>(*x);
             const auto& rhs = recurse(std::get<2>(*x));
 
-            return scelta::match([&](o_add){ return lhs + rhs; },
+            return scelta::experimental::recursive::match([&](o_add){ return lhs + rhs; },
                                  [&](o_sub){ return lhs - rhs; },
                                  [&](o_mul){ return lhs * rhs; },
                                  [&](o_div){ return lhs / rhs; })(op);

--- a/example/expression.cpp
+++ b/example/expression.cpp
@@ -48,22 +48,20 @@ int main()
     expr e = recr(2, o_mul{}, recr(5, o_add{}, recr(15, o_div{}, 3)));
 
     // clang-format off
-    std::cout << scelta::recursive::match<num>(
-        [](auto, const num& x)
-        {
-            return x;
-        },
+    std::cout << scelta::experimental::recursive::match<num>(
+        [](const num& x){ return x; }
+    )(
         [](auto recurse, const std::unique_ptr<recr_expr>& x)
         {
             const auto& lhs = std::get<0>(*x);
             const auto& op  = std::get<1>(*x);
             const auto& rhs = recurse(std::get<2>(*x));
 
-            return scelta::experimental::recursive::match([&](o_add){ return lhs + rhs; },
-                                 [&](o_sub){ return lhs - rhs; },
-                                 [&](o_mul){ return lhs * rhs; },
-                                 [&](o_div){ return lhs / rhs; })(op);
-        })
-        (e);
+            return scelta::experimental::recursive::match(
+                [&](o_add){ return lhs + rhs; },
+                [&](o_sub){ return lhs - rhs; },
+                [&](o_mul){ return lhs * rhs; },
+                [&](o_div){ return lhs / rhs; })(op);
+    })(e);
     // clang-format on
 }

--- a/example/expression.cpp
+++ b/example/expression.cpp
@@ -48,7 +48,8 @@ int main()
     expr e = recr(2, o_mul{}, recr(5, o_add{}, recr(15, o_div{}, 3)));
 
     // clang-format off
-    std::cout << scelta::experimental::recursive::match<num>(
+    // (The return type is deduced from the base cases.)
+    std::cout << scelta::match(
         [](const num& x){ return x; }
     )(
         [](auto recurse, const std::unique_ptr<recr_expr>& x)
@@ -57,7 +58,7 @@ int main()
             const auto& op  = std::get<1>(*x);
             const auto& rhs = recurse(std::get<2>(*x));
 
-            return scelta::experimental::recursive::match(
+            return scelta::match(
                 [&](o_add){ return lhs + rhs; },
                 [&](o_sub){ return lhs - rhs; },
                 [&](o_mul){ return lhs * rhs; },

--- a/include/scelta.hpp
+++ b/include/scelta.hpp
@@ -7,6 +7,7 @@
 #include "./scelta/meta.hpp"
 #include "./scelta/utils.hpp"
 #include "./scelta/recursive.hpp"
+#include "./scelta/nonrecursive.hpp"
+#include "./scelta/match.hpp"
 #include "./scelta/support.hpp"
 #include "./scelta/traits.hpp"
-#include "./scelta/visitation.hpp"

--- a/include/scelta/match.hpp
+++ b/include/scelta/match.hpp
@@ -1,0 +1,7 @@
+// Copyright (c) 2017 Vittorio Romeo
+// MIT License |  https://opensource.org/licenses/MIT
+// http://vittorioromeo.info | vittorio.romeo@outlook.com
+
+#pragma once
+
+#include "./match/match.hpp"

--- a/include/scelta/match/match.hpp
+++ b/include/scelta/match/match.hpp
@@ -12,13 +12,13 @@
 #include "../utils/fwd.hpp"
 #include "../utils/overload.hpp"
 #include "../utils/returns.hpp"
-#include "../visitation/visit.hpp"
-#include "./match.hpp"
-#include "./original_type.hpp"
-#include "./visit.hpp"
+#include "../nonrecursive/visit.hpp"
+#include "../recursive/match.hpp"
+#include "../recursive/original_type.hpp"
+#include "../recursive/visit.hpp"
 #include <type_traits>
 
-namespace scelta::experimental::recursive
+namespace scelta
 {
     namespace impl
     {
@@ -112,9 +112,10 @@ namespace scelta::experimental::recursive
 
         private:
             template <typename... Xs>
-            constexpr decltype(auto) do_non_recursive(Xs&&... xs)
+            constexpr auto do_non_recursive(Xs&&... xs) SCELTA_NOEXCEPT_AND_TRT(
+                ::scelta::nonrecursive::visit(std::declval<BCO&>(), FWD(xs)...))
             {
-                return ::scelta::visit(static_cast<BCO&>(*this), FWD(xs)...);
+                return ::scelta::nonrecursive::visit(static_cast<BCO&>(*this), FWD(xs)...);
             }
 
             template <typename... Xs>
@@ -182,5 +183,3 @@ namespace scelta::experimental::recursive
         )
     // clang-format on
 }
-
-// TODO: complete

--- a/include/scelta/meta.hpp
+++ b/include/scelta/meta.hpp
@@ -4,8 +4,9 @@
 
 #pragma once
 
-#include "./meta/copy_cv_ptr_ref.hpp"
 #include "./meta/always_false.hpp"
+#include "./meta/copy_cv_ptr_ref.hpp"
+#include "./meta/fn_ref_wrapper.hpp"
 #include "./meta/forward_like.hpp"
 #include "./meta/replace_all.hpp"
 #include "./meta/y_combinator.hpp"

--- a/include/scelta/meta/always_false.hpp
+++ b/include/scelta/meta/always_false.hpp
@@ -6,7 +6,6 @@
 
 #include <type_traits>
 
-// Usage of C++17: nested `namespace`.
 namespace scelta::meta
 {
     /// @brief Wrapper around `std::false_type`.
@@ -14,9 +13,8 @@ namespace scelta::meta
     /// It always evaluates to `std::false_type`, but it doesn't immediately
     /// trigger a static assertion as it depends on `T`.
     template <typename T>
-    struct always_false
+    struct always_false : std::false_type
     {
-        using type = std::false_type;
     };
 
     /// @brief Type alias for `always_false`.

--- a/include/scelta/meta/copy_cv_ptr_ref.hpp
+++ b/include/scelta/meta/copy_cv_ptr_ref.hpp
@@ -6,7 +6,6 @@
 
 #include <type_traits>
 
-// Usage of C++17: nested `namespace`.
 namespace scelta::meta
 {
     /// @brief Removes cv-qualifiers and references from `T`.

--- a/include/scelta/meta/fn_ref_wrapper.hpp
+++ b/include/scelta/meta/fn_ref_wrapper.hpp
@@ -6,19 +6,27 @@
 
 #include "../utils/fwd.hpp"
 #include "../utils/returns.hpp"
+#include <type_traits>
 
-namespace scelta::traits::impl
+namespace scelta::meta
 {
-    // Without `dispatch` every user-provided trait specialization would require
-    // `const` in `operator()`.
-    template <typename Trait>
-    struct dispatch
+    /// @brief `constexpr`-friendly function object reference wrapper.
+    template <typename F>
+    struct fn_ref_wrapper
     {
+        static_assert(std::is_reference_v<F>);
+
+        F _f;
+
+        constexpr fn_ref_wrapper(F f) noexcept : _f{FWD(f)}
+        {
+        }
+
         // clang-format off
         template <typename... Ts>
         constexpr auto operator()(Ts&&... xs) const
             SCELTA_RETURNS(
-                Trait{}(FWD(xs)...)
+                FWD(_f)(FWD(xs)...)
             )
         // clang-format on
     };

--- a/include/scelta/meta/forward_like.hpp
+++ b/include/scelta/meta/forward_like.hpp
@@ -7,7 +7,6 @@
 #include "../utils/returns.hpp"
 #include <type_traits>
 
-// Usage of C++17: nested `namespace`.
 namespace scelta::meta
 {
     /// @brief Applies `T`'s value category on `Source`.

--- a/include/scelta/meta/replace_all.hpp
+++ b/include/scelta/meta/replace_all.hpp
@@ -7,14 +7,15 @@
 #include "./copy_cv_ptr_ref.hpp"
 #include <type_traits>
 
-// Usage of C++17: nested `namespace`.
 namespace scelta::meta
 {
     namespace impl
     {
+        /// @brief Matches types exactly equivalent to `T`.
         template <typename T>
         using identity_check = T;
 
+        /// @brief Replaces types with exactly `T`.
         template <typename, typename T>
         using identity_replace = T;
 

--- a/include/scelta/meta/y_combinator.hpp
+++ b/include/scelta/meta/y_combinator.hpp
@@ -6,70 +6,43 @@
 
 #include "../utils/fwd.hpp"
 #include "../utils/returns.hpp"
+#include "./fn_ref_wrapper.hpp"
 #include <type_traits>
 
-// Usage of C++17: nested `namespace`.
 namespace scelta::meta
 {
-    namespace impl
+    /// @brief Provides a Y combinator wrapper for a `FunctionObject`. The
+    /// wrapper is `constexpr`/`noexcept`/SFINAE-friendly.
+    /// @details See this proposal:
+    /// http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0200r0.html
+    template <typename F>
+    struct y_combinator : F
     {
-        /// @brief `constexpr`-friendly function object reference wrapper.
-        template <typename F>
-        struct fn_ref_wrapper
+        template <typename FFwd>
+        constexpr y_combinator(FFwd&& f) noexcept(noexcept(F(FWD(f))))
+            : F(FWD(f))
         {
-            static_assert(std::is_reference_v<F>);
+        }
 
-            F _f;
-
-            constexpr fn_ref_wrapper(F f) noexcept : _f{FWD(f)}
-            {
-            }
-
-            // clang-format off
-            template <typename... Ts>
-            constexpr auto operator()(Ts&&... xs) const
-                SCELTA_RETURNS(
-                    FWD(_f)(FWD(xs)...)
-                )
-            // clang-format on
-        };
-
-        template <typename F>
-        struct y_combinator_wrapper : F
-        {
-            template <typename FFwd>
-            constexpr y_combinator_wrapper(FFwd&& f) noexcept(
-                noexcept(F(FWD(f))))
-                : F(FWD(f))
-            {
-            }
-
-#define DEFINE_CALL_OPERATOR(m_refq)                                      \
-    template <typename... Ts>                                             \
-    constexpr auto operator()(Ts&&... xs) m_refq SCELTA_NOEXCEPT_AND_TRT( \
-        std::declval<F m_refq>()(                                         \
-            std::declval<fn_ref_wrapper<y_combinator_wrapper m_refq>>(),  \
-            FWD(xs)...))                                                  \
-    {                                                                     \
-        return static_cast<F m_refq>(*this)(                              \
-            fn_ref_wrapper<y_combinator_wrapper m_refq>{                  \
-                static_cast<y_combinator_wrapper m_refq>(*this)},         \
-            FWD(xs)...);                                                  \
+#define DEFINE_CALL_OPERATOR(m_refq)                                          \
+    template <typename... Ts>                                                 \
+    constexpr auto operator()(Ts&&... xs) m_refq SCELTA_NOEXCEPT_AND_TRT(     \
+        std::declval<F m_refq>()(                                             \
+            std::declval<fn_ref_wrapper<y_combinator m_refq>>(), FWD(xs)...)) \
+    {                                                                         \
+        return static_cast<F m_refq>(*this)(                                  \
+            fn_ref_wrapper<y_combinator m_refq>{                              \
+                static_cast<y_combinator m_refq>(*this)},                     \
+            FWD(xs)...);                                                      \
     }
 
-            DEFINE_CALL_OPERATOR(&)
-            DEFINE_CALL_OPERATOR(const&)
-            DEFINE_CALL_OPERATOR(&&)
+        DEFINE_CALL_OPERATOR(&)
+        DEFINE_CALL_OPERATOR(const&)
+        DEFINE_CALL_OPERATOR(&&)
 
 #undef DEFINE_CALL_OPERATOR
-        };
-    }
+    };
 
-    // clang-format off
-    template <typename F>
-    auto y_combinator(F&& f)
-        SCELTA_RETURNS(
-            impl::y_combinator_wrapper<std::decay_t<F>>(FWD(f))
-        )
-    // clang-format on
+    template <typename FFwd>
+    y_combinator(FFwd &&)->y_combinator<std::decay_t<FFwd>>;
 }

--- a/include/scelta/nonrecursive.hpp
+++ b/include/scelta/nonrecursive.hpp
@@ -4,5 +4,5 @@
 
 #pragma once
 
-#include "./visitation/visit.hpp"
-#include "./visitation/match.hpp"
+#include "./nonrecursive/match.hpp"
+#include "./nonrecursive/visit.hpp"

--- a/include/scelta/nonrecursive/match.hpp
+++ b/include/scelta/nonrecursive/match.hpp
@@ -26,9 +26,9 @@ namespace scelta
     template <typename... Variants>                                        \
     constexpr auto operator()(Variants&&... variants) m_refq               \
     SCELTA_NOEXCEPT_AND_TRT(                                               \
-        ::scelta::visit(std::declval<Visitor m_refq>(), FWD(variants)...)) \
+        ::scelta::nonrecursive::visit(std::declval<Visitor m_refq>(), FWD(variants)...)) \
     {                                                                      \
-        return ::scelta::visit(                                            \
+        return ::scelta::nonrecursive::visit(                                            \
             static_cast<Visitor m_refq>(*this), FWD(variants)...);         \
     }
 
@@ -47,11 +47,14 @@ namespace scelta
         // clang-format on
     }
 
-    // clang-format off
-    template <typename... Fs>
-    constexpr auto match(Fs&&... fs)
-        SCELTA_RETURNS(
-            impl::make_bound_visitor(::scelta::overload(FWD(fs)...))
-        )
-    // clang-format on
+    namespace nonrecursive
+    {
+        // clang-format off
+        template <typename... Fs>
+        constexpr auto match(Fs&&... fs)
+            SCELTA_RETURNS(
+                impl::make_bound_visitor(::scelta::overload(FWD(fs)...))
+            )
+        // clang-format on
+    }
 }

--- a/include/scelta/nonrecursive/visit.hpp
+++ b/include/scelta/nonrecursive/visit.hpp
@@ -5,9 +5,9 @@
 #pragma once
 
 #include "../traits/adt/valid.hpp"
-#include "../utils/returns.hpp"
 #include "../utils/assert.hpp"
 #include "../utils/homogenizer.hpp"
+#include "../utils/returns.hpp"
 
 namespace scelta
 {
@@ -36,7 +36,10 @@ namespace scelta
     }
     // clang-format on
 
-    template <typename... Ts>
-    constexpr auto visit(Ts&&... xs)
-        SCELTA_RETURNS(impl::visit_impl(impl::non_recursive_tag{}, FWD(xs)...))
+    namespace nonrecursive
+    {
+        template <typename... Ts>
+        constexpr auto visit(Ts&&... xs) SCELTA_RETURNS(
+            impl::visit_impl(impl::non_recursive_tag{}, FWD(xs)...))
+    }
 }

--- a/include/scelta/recursive/experimental_match.hpp
+++ b/include/scelta/recursive/experimental_match.hpp
@@ -123,17 +123,15 @@ namespace scelta::experimental::recursive
                 // "Base case overload" with one extra argument (+1 arity).
                 auto adapted_bco = [bco = static_cast<BCO&&>(*this)] //
                     (auto, auto&&... ys) mutable                     //
-                    SCELTA_NOEXCEPT_AND_TRT(std::declval<BCO&&>()(FWD(ys)...))
-                {
-                    return bco(FWD(ys)...);
-                };
+                    SCELTA_NOEXCEPT_AND_TRT(std::declval<BCO&&>()(FWD(ys)...)) {
+                        return bco(FWD(ys)...);
+                    };
 
                 // Overload of "adapted BCO" and "recursive cases".
                 auto o = overload(std::move(adapted_bco), FWD(xs)...);
 
                 return [urv = make_unresolved_visitor(std::move(o))](
-                    auto&&... vs) mutable->decltype(auto)
-                {
+                           auto&&... vs) mutable -> decltype(auto) {
                     using rt = applied_return_type<Return, BCO&,
                         original_decay_first_alternative_t<decltype(vs)>...>;
 

--- a/include/scelta/recursive/experimental_match.hpp
+++ b/include/scelta/recursive/experimental_match.hpp
@@ -7,15 +7,15 @@
 #include "../meta/forward_like.hpp"
 #include "../meta/replace_all.hpp"
 #include "../meta/y_combinator.hpp"
+#include "../traits/adt/alternatives.hpp"
+#include "../traits/adt/is_visitable.hpp"
 #include "../utils/fwd.hpp"
-#include "../utils/returns.hpp"
 #include "../utils/overload.hpp"
+#include "../utils/returns.hpp"
 #include "../visitation/visit.hpp"
-#include "./visit.hpp"
 #include "./match.hpp"
 #include "./original_type.hpp"
-#include "../traits/adt/is_visitable.hpp"
-#include "../traits/adt/alternatives.hpp"
+#include "./visit.hpp"
 #include <type_traits>
 
 namespace scelta::experimental::recursive
@@ -25,7 +25,33 @@ namespace scelta::experimental::recursive
         // Tag type that when passed to `match` attempts to deduce the return
         // type by invoking the base case overload set with the first
         // alternative of the visitable.
-        struct deduce_rt { };
+        struct deduce_rt
+        {
+        };
+
+        // SFINAE-friendly return type dispatch.
+        // Not-deduced case: evaluate to `Return`.
+        template <typename Return>
+        struct return_type
+        {
+            template <typename...>
+            using apply = Return;
+        };
+
+        // SFINAE-friendly return type dispatch.
+        // Deduced case: evaluate to result of `F(Ts...)`.
+        template <>
+        struct return_type<deduce_rt>
+        {
+            template <typename F, typename... Ts>
+            using apply = std::result_of_t<F(Ts...)>;
+        };
+
+        // SFINAE-friendly return type dispatch.
+        // Alias for `return_type<Return>::apply<F, Ts...>`.
+        template <typename Return, typename F, typename... Ts>
+        using applied_return_type =
+            typename return_type<Return>::template apply<F, Ts...>;
 
         template <typename T>
         using original_decay_t =
@@ -39,8 +65,7 @@ namespace scelta::experimental::recursive
         struct unresolved_visitor : O
         {
             template <typename OFwd>
-            constexpr unresolved_visitor(OFwd&& o) noexcept(
-                noexcept(O{FWD(o)}))
+            constexpr unresolved_visitor(OFwd&& o) noexcept(noexcept(O{FWD(o)}))
                 : O{FWD(o)}
             {
             }
@@ -53,10 +78,8 @@ namespace scelta::experimental::recursive
                     // Recurse on this lambda via Y combinator to pass it back
                     // as part of the bound `recurse` argument.
                     [this](auto self, auto&&... xs) mutable->Return {
-                        // TODO: does `this` live long enough?
                         // Invoke the overload...
                         return static_cast<O&>(*this)(
-
                             // Passing a visitor that invokes `self` to the
                             // `recurse` argument.
                             [&self](auto&&... vs) -> Return {
@@ -73,13 +96,12 @@ namespace scelta::experimental::recursive
 
         template <typename BCO>
         constexpr auto make_unresolved_visitor(BCO&& bco)
-            SCELTA_RETURNS(
-                unresolved_visitor<std::decay_t<BCO>>{FWD(bco)}
-            )
+            SCELTA_RETURNS(unresolved_visitor<std::decay_t<BCO>>{FWD(bco)})
 
 
-        template <typename Return, typename BCO>
-        struct with_bound_base_cases : private BCO // "base case overload", EBO
+                template <typename Return, typename BCO>
+                struct with_bound_base_cases
+            : private BCO // "base case overload", EBO
         {
             template <typename BCOFwd>
             constexpr with_bound_base_cases(BCOFwd&& bco) noexcept(
@@ -88,40 +110,53 @@ namespace scelta::experimental::recursive
             {
             }
 
+        private:
             template <typename... Xs>
-            constexpr auto operator()(Xs&&... xs)
+            constexpr decltype(auto) do_non_recursive(Xs&&... xs)
             {
-                constexpr bool has_recursive_cases = !(::scelta::traits::adt::is_visitable_v<Xs&&> && ...);
+                return ::scelta::visit(static_cast<BCO&>(*this), FWD(xs)...);
+            }
+
+            template <typename... Xs>
+            constexpr auto defer_recursive(Xs&&... xs)
+            {
+                // "Base case overload" with one extra argument (+1 arity).
+                auto adapted_bco = [bco = static_cast<BCO&&>(*this)] //
+                    (auto, auto&&... ys) mutable                     //
+                    SCELTA_NOEXCEPT_AND_TRT(std::declval<BCO&&>()(FWD(ys)...))
+                {
+                    return bco(FWD(ys)...);
+                };
+
+                // Overload of "adapted BCO" and "recursive cases".
+                auto o = overload(std::move(adapted_bco), FWD(xs)...);
+
+                return [urv = make_unresolved_visitor(std::move(o))](
+                    auto&&... vs) mutable->decltype(auto)
+                {
+                    using rt = applied_return_type<Return, BCO&,
+                        original_decay_first_alternative_t<decltype(vs)>...>;
+
+                    auto resolved_vis = urv.template resolve<rt>();
+                    return ::scelta::recursive::visit<rt>(
+                        resolved_vis, FWD(vs)...);
+                };
+            }
+
+        public:
+            template <typename... Xs>
+            constexpr decltype(auto) operator()(Xs&&... xs)
+            {
+                constexpr bool has_recursive_cases =
+                    !(::scelta::traits::adt::is_visitable_v<Xs&&> && ...);
 
                 if constexpr(has_recursive_cases)
                 {
-                    // base case overload with one extra argument (+1 arity)
-                    auto adapted_bco = [bco = static_cast<BCO&&>(*this)]
-                        (auto, auto&&... xs) mutable SCELTA_NOEXCEPT_AND_TRT(std::declval<BCO&&>()(FWD(xs)...)) {
-                            return bco(FWD(xs)...);
-                        };
-
-                    auto o = overload(std::move(adapted_bco), FWD(xs)...);
-                    return [rv = make_unresolved_visitor(std::move(o))](auto&&... vs) mutable
-                    {
-                        // TODO: SFINAE out the conditional because result_of might create instantiation error
-                        using rt = std::conditional_t<
-                            std::is_same_v<Return, deduce_rt>,
-
-                            // result of calling BCO& (unadapted overload) with the first alternative of each variant
-                            std::result_of_t<BCO&(original_decay_first_alternative_t<decltype(vs)>...)>,
-
-                            // user-specified return type
-                            Return
-                        >;
-
-                        auto resolved_vis = rv.template resolve<rt>();
-                        return ::scelta::recursive::visit<rt>(resolved_vis, FWD(vs)...);
-                    };
+                    return defer_recursive(FWD(xs)...);
                 }
                 else
                 {
-                    return ::scelta::visit(static_cast<BCO&>(*this), FWD(xs)...);
+                    return do_non_recursive(FWD(xs)...);
                 }
             }
         };

--- a/include/scelta/recursive/match.hpp
+++ b/include/scelta/recursive/match.hpp
@@ -6,7 +6,7 @@
 
 #include "../meta/y_combinator.hpp"
 #include "../utils/fwd.hpp"
-#include "../visitation/visit.hpp"
+#include "../nonrecursive/visit.hpp"
 #include "../recursive/visit.hpp"
 #include "./visit.hpp"
 

--- a/include/scelta/recursive/match.hpp
+++ b/include/scelta/recursive/match.hpp
@@ -7,6 +7,7 @@
 #include "../meta/y_combinator.hpp"
 #include "../utils/fwd.hpp"
 #include "../visitation/visit.hpp"
+#include "../recursive/visit.hpp"
 #include "./visit.hpp"
 
 namespace scelta::recursive

--- a/include/scelta/recursive/visit.hpp
+++ b/include/scelta/recursive/visit.hpp
@@ -6,7 +6,7 @@
 
 #include "../meta/copy_cv_ptr_ref.hpp"
 #include "../utils/fwd.hpp"
-#include "../visitation/visit.hpp"
+#include "../nonrecursive/visit.hpp"
 #include "./original_type.hpp"
 #include <type_traits>
 

--- a/include/scelta/support/optional/boost.hpp
+++ b/include/scelta/support/optional/boost.hpp
@@ -6,7 +6,6 @@
 #ifndef SCELTA_SUPPORT_OPTIONAL_BOOST_DISABLE
 
 // clang-format off
-// Usage of C++17: `__has_include`.
 #if __has_include(<boost/optional.hpp>) && __has_include(<boost/none.hpp>)
 // clang-format on
 

--- a/include/scelta/support/optional/std.hpp
+++ b/include/scelta/support/optional/std.hpp
@@ -6,11 +6,9 @@
 #ifndef SCELTA_SUPPORT_OPTIONAL_STD_DISABLE
 
 // clang-format off
-// Usage of C++17: `__has_include`.
 #if __has_include(<optional>)
 // clang-format on
 
-// Usage of C++17: `<optional>`.
 #include "../../utils/optional_utils.hpp"
 #include "../../traits/adt/visit.hpp"
 #include <optional>

--- a/include/scelta/support/optional/type_safe.hpp
+++ b/include/scelta/support/optional/type_safe.hpp
@@ -6,7 +6,6 @@
 #ifndef SCELTA_SUPPORT_OPTIONAL_TYPE_SAFE_DISABLE
 
 // clang-format off
-// Usage of C++17: `__has_include`.
 #if __has_include(<type_safe/optional.hpp>)
 // clang-format on
 

--- a/include/scelta/support/variant/boost.hpp
+++ b/include/scelta/support/variant/boost.hpp
@@ -6,7 +6,6 @@
 #ifndef SCELTA_SUPPORT_VARIANT_BOOST_DISABLE
 
 // clang-format off
-// Usage of C++17: `__has_include`.
 #if __has_include(<boost/variant.hpp>)
 // clang-format on
 

--- a/include/scelta/support/variant/eggs.hpp
+++ b/include/scelta/support/variant/eggs.hpp
@@ -6,7 +6,6 @@
 #ifndef SCELTA_SUPPORT_VARIANT_EGGS_DISABLE
 
 // clang-format off
-// Usage of C++17: `__has_include`.
 #if __has_include(<eggs/variant.hpp>)
 // clang-format on
 

--- a/include/scelta/support/variant/mpark.hpp
+++ b/include/scelta/support/variant/mpark.hpp
@@ -6,7 +6,6 @@
 #ifndef SCELTA_SUPPORT_VARIANT_MPARK_DISABLE
 
 // clang-format off
-// Usage of C++17: `__has_include`.
 #if __has_include(<mpark/variant.hpp>)
 // clang-format on
 

--- a/include/scelta/support/variant/std.hpp
+++ b/include/scelta/support/variant/std.hpp
@@ -6,11 +6,9 @@
 #ifndef SCELTA_SUPPORT_VARIANT_STD_DISABLE
 
 // clang-format off
-// Usage of C++17: `__has_include`.
 #if __has_include(<variant>)
 // clang-format on
 
-// Usage of C++17: `<variant>`.
 #include "../../traits/adt/visit.hpp"
 #include "../../traits/adt/valid.hpp"
 #include "../../utils/returns.hpp"

--- a/include/scelta/support/variant/type_safe.hpp
+++ b/include/scelta/support/variant/type_safe.hpp
@@ -6,7 +6,6 @@
 #ifndef SCELTA_SUPPORT_VARIANT_TYPE_SAFE_DISABLE
 
 // clang-format off
-// Usage of C++17: `__has_include`.
 #if __has_include(<type_safe/variant.hpp>) && \
     __has_include(<type_safe/visitor.hpp>)
 // clang-format on

--- a/include/scelta/traits/adt/alternatives.hpp
+++ b/include/scelta/traits/adt/alternatives.hpp
@@ -7,7 +7,6 @@
 #include "../dispatch.hpp"
 #include <tuple>
 
-// Usage of C++17: nested `namespace`.
 namespace scelta::traits::adt
 {
     namespace impl

--- a/include/scelta/traits/adt/is_visitable.hpp
+++ b/include/scelta/traits/adt/is_visitable.hpp
@@ -7,8 +7,6 @@
 #include "./visit.hpp"
 #include <experimental/type_traits>
 
-
-// Usage of C++17: nested `namespace`.
 namespace scelta::traits::adt
 {
     namespace impl

--- a/include/scelta/traits/adt/valid.hpp
+++ b/include/scelta/traits/adt/valid.hpp
@@ -6,7 +6,6 @@
 
 #include "../dispatch.hpp"
 
-// Usage of C++17: nested `namespace`.
 namespace scelta::traits::adt
 {
     template <typename>

--- a/include/scelta/traits/adt/visit.hpp
+++ b/include/scelta/traits/adt/visit.hpp
@@ -8,7 +8,6 @@
 #include "../../utils/optional_utils.hpp"
 #include "../dispatch.hpp"
 
-// Usage of C++17: nested `namespace`.
 namespace scelta::traits::adt
 {
     namespace impl

--- a/include/scelta/traits/optional.hpp
+++ b/include/scelta/traits/optional.hpp
@@ -7,7 +7,6 @@
 #include "../utils/returns.hpp"
 #include "./dispatch.hpp"
 
-// Usage of C++17: nested `namespace`.
 namespace scelta::traits::optional
 {
     template <typename>

--- a/include/scelta/utils/access_optional.hpp
+++ b/include/scelta/utils/access_optional.hpp
@@ -8,7 +8,6 @@
 #include "./returns.hpp"
 #include <type_traits>
 
-// Usage of C++17: nested `namespace`.
 namespace scelta::impl
 {
     // clang-format off

--- a/include/scelta/utils/homogenizer.hpp
+++ b/include/scelta/utils/homogenizer.hpp
@@ -8,7 +8,6 @@
 #include "./returns.hpp"
 #include <type_traits>
 
-// Usage of C++17: nested `namespace`.
 namespace scelta::impl
 {
     struct non_recursive_tag

--- a/include/scelta/utils/overload.hpp
+++ b/include/scelta/utils/overload.hpp
@@ -14,7 +14,6 @@ namespace scelta
         template <typename... Ts>
         struct overloader : Ts...
         {
-            // Usage of C++17: fold expression.
             template <typename... Args>
             constexpr overloader(Args&&... xs) noexcept(
                 (noexcept(Ts{FWD(xs)}) && ...))
@@ -22,7 +21,6 @@ namespace scelta
             {
             }
 
-            // Usage of C++17: variadic `using`-directive.
             using Ts::operator()...;
         };
     }

--- a/include/scelta/utils/returns.hpp
+++ b/include/scelta/utils/returns.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <type_traits>
+#include "./fwd.hpp"
 
 #define SCELTA_NOEXCEPT_AND_TRT_ENABLE_IF(m_condition, ...) \
     noexcept(noexcept(__VA_ARGS__))                         \

--- a/include/scelta/utils/returns.hpp
+++ b/include/scelta/utils/returns.hpp
@@ -4,28 +4,37 @@
 
 #pragma once
 
-#include <type_traits>
 #include "./fwd.hpp"
+#include <type_traits>
 
+/// @brief This macro expands to a `noexcept`-specifier, and a `std::enable_if`
+/// trailing return type.
 #define SCELTA_NOEXCEPT_AND_TRT_ENABLE_IF(m_condition, ...) \
     noexcept(noexcept(__VA_ARGS__))                         \
         ->::std::enable_if_t<m_condition, decltype(__VA_ARGS__)>
 
+/// @brief This macro expands to a `noexcept`-specifier, and a
+/// trailing return type.
 #define SCELTA_NOEXCEPT_AND_TRT(...) \
     noexcept(noexcept(__VA_ARGS__))->decltype(__VA_ARGS__)
 
+/// @brief This macro expands to a body, `noexcept`-specifier, and a
+/// `std::enable_if` trailing return type.
 #define SCELTA_RETURNS_ENABLE_IF(m_condition, ...) \
     SCELTA_NOEXCEPT_AND_TRT_ENABLE_IF(__VA_ARGS__) \
     {                                              \
         return __VA_ARGS__;                        \
     }
 
+/// @brief This macro expands to a body, `noexcept`-specifier, and a
+/// trailing return type.
 #define SCELTA_RETURNS(...)              \
     SCELTA_NOEXCEPT_AND_TRT(__VA_ARGS__) \
     {                                    \
         return __VA_ARGS__;              \
     }
 
+/// @brief This macro expands to a body and `noexcept`-specifier.
 #define SCELTA_NOEXCEPT_AND_RETURN_BODY(...) \
     noexcept(noexcept(__VA_ARGS__))          \
     {                                        \

--- a/temp/oldem.hpp
+++ b/temp/oldem.hpp
@@ -10,7 +10,7 @@
 #include "../utils/fwd.hpp"
 #include "../utils/returns.hpp"
 #include "../utils/overload.hpp"
-#include "../visitation/visit.hpp"
+#include "../nonrecursive/visit.hpp"
 #include "./visit.hpp"
 #include "./match.hpp"
 #include "../traits.hpp"
@@ -18,7 +18,7 @@
 #include <experimental/type_traits>
 #include <type_traits>
 
-namespace scelta::experimental::recursive
+namespace scelta
 {
     namespace impl
     {
@@ -166,7 +166,7 @@ namespace scelta::experimental::recursive
                 }
                 else
                 {
-                    return ::scelta::visit(static_cast<BaseCaseOverload&>(*this), FWD(rcs)...);
+                    return ::scelta::nonrecursive::visit(static_cast<BaseCaseOverload&>(*this), FWD(rcs)...);
                 }
             }
         };

--- a/test/optional/match.cpp
+++ b/test/optional/match.cpp
@@ -2,6 +2,7 @@
 #include "../variant_test_utils.hpp"
 #include <scelta/visitation.hpp>
 #include <scelta/traits/adt/alternatives.hpp>
+#include <scelta/recursive/experimental_match.hpp>
 
 TEST_MAIN()
 {
@@ -18,7 +19,7 @@ TEST_MAIN()
                 int>);
 
             {
-                auto f = scelta::match(     //
+                auto f = scelta::experimental::recursive::match(     //
                     [](null) { return 0; }, //
                     [](int)  { return 1; });
 
@@ -27,7 +28,7 @@ TEST_MAIN()
             }
 
             {
-                auto f = scelta::match(           //
+                auto f = scelta::experimental::recursive::match(           //
                     [](null, null) { return 0; }, //
                     [](null, int)  { return 1; }, //
                     [](int,  null) { return 2; }, //

--- a/test/optional/nonrecursive_match.cpp
+++ b/test/optional/nonrecursive_match.cpp
@@ -1,7 +1,7 @@
 #include "../test_utils.hpp"
 #include "../variant_test_utils.hpp"
 #include <scelta/traits/adt/alternatives.hpp>
-#include <scelta/match.hpp>
+#include <scelta/nonrecursive/match.hpp>
 
 TEST_MAIN()
 {
@@ -18,7 +18,7 @@ TEST_MAIN()
                 int>);
 
             {
-                auto f = scelta::match(     //
+                auto f = scelta::nonrecursive::match(     //
                     [](null) { return 0; }, //
                     [](int)  { return 1; });
 
@@ -27,7 +27,7 @@ TEST_MAIN()
             }
 
             {
-                auto f = scelta::match(           //
+                auto f = scelta::nonrecursive::match(           //
                     [](null, null) { return 0; }, //
                     [](null, int)  { return 1; }, //
                     [](int,  null) { return 2; }, //

--- a/test/optional/visit.cpp
+++ b/test/optional/visit.cpp
@@ -1,6 +1,6 @@
 #include "../test_utils.hpp"
 #include "../variant_test_utils.hpp"
-#include <scelta/visitation.hpp>
+#include <scelta/nonrecursive/visit.hpp>
 
 TEST_MAIN()
 {
@@ -17,8 +17,8 @@ TEST_MAIN()
                     [](null) { return 0; }, //
                     [](int)  { return 1; });
 
-                EXPECT_EQ(scelta::visit(f, make()),  0);
-                EXPECT_EQ(scelta::visit(f, make(0)), 1);
+                EXPECT_EQ(scelta::nonrecursive::visit(f, make()),  0);
+                EXPECT_EQ(scelta::nonrecursive::visit(f, make(0)), 1);
             }
 
             {
@@ -28,10 +28,10 @@ TEST_MAIN()
                     [](int,  null) { return 2; }, //
                     [](int,  int)  { return 3; });
 
-                EXPECT_EQ(scelta::visit(f, make(),  make()),  0);
-                EXPECT_EQ(scelta::visit(f, make(),  make(0)), 1);
-                EXPECT_EQ(scelta::visit(f, make(0), make()),  2);
-                EXPECT_EQ(scelta::visit(f, make(0), make(0)), 3);
+                EXPECT_EQ(scelta::nonrecursive::visit(f, make(),  make()),  0);
+                EXPECT_EQ(scelta::nonrecursive::visit(f, make(),  make(0)), 1);
+                EXPECT_EQ(scelta::nonrecursive::visit(f, make(0), make()),  2);
+                EXPECT_EQ(scelta::nonrecursive::visit(f, make(0), make(0)), 3);
             }
 
             {
@@ -41,8 +41,8 @@ TEST_MAIN()
                     [&](null) -> int& { return a; }, //
                     [&](int)  -> int& { return b; });
 
-                EXPECT_EQ(&scelta::visit(f, make()),  &a);
-                EXPECT_EQ(&scelta::visit(f, make(0)), &b);
+                EXPECT_EQ(&scelta::nonrecursive::visit(f, make()),  &a);
+                EXPECT_EQ(&scelta::nonrecursive::visit(f, make(0)), &b);
             }
         });
     // clang-format on

--- a/test/optional/visit.cpp
+++ b/test/optional/visit.cpp
@@ -33,6 +33,17 @@ TEST_MAIN()
                 EXPECT_EQ(scelta::visit(f, make(0), make()),  2);
                 EXPECT_EQ(scelta::visit(f, make(0), make(0)), 3);
             }
+
+            {
+                int a = 0;
+                int b = 0;
+                auto f = scelta::overload(  //
+                    [&](null) -> int& { return a; }, //
+                    [&](int)  -> int& { return b; });
+
+                EXPECT_EQ(&scelta::visit(f, make()),  &a);
+                EXPECT_EQ(&scelta::visit(f, make(0)), &b);
+            }
         });
     // clang-format on
 }

--- a/test/recursive/match_recursive_experimental.cpp
+++ b/test/recursive/match_recursive_experimental.cpp
@@ -6,12 +6,12 @@
 #include "../variant_test_utils.hpp"
 #include <memory>
 #include <scelta/recursive.hpp>
-#include <scelta/recursive/experimental_match.hpp>
+#include <scelta/match.hpp>
 #include <scelta/support.hpp>
 #include <vector>
 
 namespace sr = scelta::recursive;
-namespace ser = scelta::experimental::recursive;
+namespace ser = scelta;
 using _ = sr::placeholder;
 
 template <template <typename...> typename Variant>
@@ -69,13 +69,6 @@ struct test_case
                        [&](auto recurse, const auto& v) { for(const auto& x : v) recurse(x); })(v);
 
             EXPECT_EQ(acc, 6);
-
-/* TODO: ?
-            ser::match([&](auto x) { acc += x; })(
-                       [&](auto recurse, const r0& v) { for(const auto& x : v) recurse(x); })(v);
-
-            EXPECT_EQ(acc, 8);
-*/
         }
 
         {

--- a/test/recursive/match_recursive_experimental_2.cpp
+++ b/test/recursive/match_recursive_experimental_2.cpp
@@ -7,12 +7,12 @@
 #include "../variant_test_utils.hpp"
 #include <memory>
 #include <scelta/recursive.hpp>
-#include <scelta/recursive/experimental_match.hpp>
+#include <scelta/match.hpp>
 #include <scelta/support.hpp>
 #include <vector>
 
 namespace sr = scelta::recursive;
-namespace ser = scelta::experimental::recursive;
+namespace ser = scelta;
 using _ = sr::placeholder;
 
 struct f

--- a/test/recursive/match_recursive_experimental_2.cpp
+++ b/test/recursive/match_recursive_experimental_2.cpp
@@ -62,6 +62,21 @@ struct test_case
             EXPECT_EQ(m(v1), 1);
         }
 
+        // concrete multiple base cases, no recursive cases, return reference
+        {
+            int a = 0;
+            int b = 0;
+
+            Variant<int, char> v0{0};
+            Variant<int, char> v1{'a'};
+
+            auto m = ser::match([&](int)  -> int& { return a; },
+                                [&](char) -> int& { return b; });
+
+            EXPECT_EQ(&m(v0), &a);
+            EXPECT_EQ(&m(v1), &b);
+        }
+
         // auto single base case, no recursive cases
         {
             Variant<int, char> v0{0};

--- a/test/utils/overload.cpp
+++ b/test/utils/overload.cpp
@@ -81,6 +81,17 @@ TEST_MAIN()
         EXPECT_EQ(l1('a'), 0);
     }
 
+    {
+        int a;
+        int b;
+        auto f = scelta::overload(         //
+            [&](int) -> int& { return a; }, //
+            [&](auto) -> int& { return b; });
+
+        EXPECT_EQ(&f(0), &a);
+        EXPECT_EQ(&f('a'), &b);
+    }
+
     /*
     // ref overload
     {

--- a/test/variant/match.cpp
+++ b/test/variant/match.cpp
@@ -1,6 +1,7 @@
 #include "../test_utils.hpp"
 #include "../variant_test_utils.hpp"
 #include <scelta/visitation.hpp>
+#include <scelta/recursive/experimental_match.hpp>
 
 TEST_MAIN()
 {
@@ -13,7 +14,7 @@ TEST_MAIN()
         {
             {
                 auto v = make(1);
-                scelta::match(                          //
+                scelta::experimental::recursive::match(                          //
                     [](int x) { EXPECT_OP(x, ==, 1); }, //
                     [](float) { EXPECT(false); },       //
                     [](char)  { EXPECT(false); })(v);
@@ -21,7 +22,7 @@ TEST_MAIN()
 
             {
                 auto v = make(2.f);
-                scelta::match(                              //
+                scelta::experimental::recursive::match(                              //
                     [](int)     { EXPECT(false); },         //
                     [](float x) { EXPECT_OP(x, ==, 2.f); }, //
                     [](char)    { EXPECT(false); })(v);
@@ -29,7 +30,7 @@ TEST_MAIN()
 
             {
                 auto v = make('c');
-                scelta::match(                     //
+                scelta::experimental::recursive::match(                     //
                     [](int)    { EXPECT(false); }, //
                     [](float)  { EXPECT(false); }, //
                     [](char x) { EXPECT_OP(x, ==, 'c'); })(v);
@@ -42,7 +43,7 @@ TEST_MAIN()
 
                 auto v = make(1);
                 EXPECT_EQ(&a,                            //
-                    &scelta::match(                      //
+                    &scelta::experimental::recursive::match(                      //
                         [&](int)  -> int& { return a; }, //
                         [&](auto) -> int& { return b; })(v));
             }

--- a/test/variant/match.cpp
+++ b/test/variant/match.cpp
@@ -34,6 +34,18 @@ TEST_MAIN()
                     [](float)  { EXPECT(false); }, //
                     [](char x) { EXPECT_OP(x, ==, 'c'); })(v);
             }
+
+
+            {
+                int a;
+                int b;
+
+                auto v = make(1);
+                EXPECT_EQ(&a,                            //
+                    &scelta::match(                      //
+                        [&](int)  -> int& { return a; }, //
+                        [&](auto) -> int& { return b; })(v));
+            }
         });
     // clang-format on
 }

--- a/test/variant/match_auto.cpp
+++ b/test/variant/match_auto.cpp
@@ -1,5 +1,6 @@
 #include "../test_utils.hpp"
 #include "../variant_test_utils.hpp"
+#include <scelta/recursive/experimental_match.hpp>
 #include <scelta/visitation.hpp>
 
 // clang-format off
@@ -58,7 +59,7 @@ TEST_MAIN()
         {
             {
                 auto v = make(a{});
-                scelta::match(
+                scelta::experimental::recursive::match(
                     [](a x) {                return x.foo(); },
                     [](b x) { EXPECT(false); return x.bar(); },
                     [](c x) { EXPECT(false); return x.bar(); })(v);
@@ -83,19 +84,19 @@ TEST_MAIN()
                 * http://stackoverflow.com/questions/43982799
                 */
 
-                scelta::match(
+                scelta::experimental::recursive::match(
                     [](a x)                         {                return x.foo(); },
                     [](auto x) -> decltype(x.bar()) { EXPECT(false); return x.bar(); })(v);
             }
 
             {
                 auto v = make(b{});
-                scelta::match(
+                scelta::experimental::recursive::match(
                     [](a x) { EXPECT(false); return x.foo(); },
                     [](b x) {                return x.bar(); },
                     [](c x) { EXPECT(false); return x.bar(); })(v);
 
-                scelta::match(
+                scelta::experimental::recursive::match(
                     [](a x)                         { EXPECT(false); return x.foo(); },
                     [](auto x) -> decltype(x.bar()) {                return x.bar(); })(v);
                 // TODO: match linearly?

--- a/test/variant/match_multi.cpp
+++ b/test/variant/match_multi.cpp
@@ -1,5 +1,6 @@
 #include "../test_utils.hpp"
 #include "../variant_test_utils.hpp"
+#include <scelta/recursive/experimental_match.hpp>
 #include <scelta/visitation.hpp>
 
 struct a
@@ -25,7 +26,7 @@ TEST_MAIN()
         [](auto make)                 //
         {
             {
-                auto f = scelta::match(     //
+                auto f = scelta::experimental::recursive::match(     //
                     [](a, a) { return 0; }, //
                     [](a, b) { return 1; }, //
                     [](b, b) { return 2; }, //

--- a/test/variant/nonrecursive_match.cpp
+++ b/test/variant/nonrecursive_match.cpp
@@ -1,6 +1,6 @@
 #include "../test_utils.hpp"
 #include "../variant_test_utils.hpp"
-#include <scelta/match.hpp>
+#include <scelta/nonrecursive/match.hpp>
 
 TEST_MAIN()
 {
@@ -13,7 +13,7 @@ TEST_MAIN()
         {
             {
                 auto v = make(1);
-                scelta::match(                          //
+                scelta::nonrecursive::match(                          //
                     [](int x) { EXPECT_OP(x, ==, 1); }, //
                     [](float) { EXPECT(false); },       //
                     [](char)  { EXPECT(false); })(v);
@@ -21,7 +21,7 @@ TEST_MAIN()
 
             {
                 auto v = make(2.f);
-                scelta::match(                              //
+                scelta::nonrecursive::match(                              //
                     [](int)     { EXPECT(false); },         //
                     [](float x) { EXPECT_OP(x, ==, 2.f); }, //
                     [](char)    { EXPECT(false); })(v);
@@ -29,7 +29,7 @@ TEST_MAIN()
 
             {
                 auto v = make('c');
-                scelta::match(                     //
+                scelta::nonrecursive::match(                     //
                     [](int)    { EXPECT(false); }, //
                     [](float)  { EXPECT(false); }, //
                     [](char x) { EXPECT_OP(x, ==, 'c'); })(v);
@@ -42,7 +42,7 @@ TEST_MAIN()
 
                 auto v = make(1);
                 EXPECT_EQ(&a,                            //
-                    &scelta::match(                      //
+                    &scelta::nonrecursive::match(                      //
                         [&](int)  -> int& { return a; }, //
                         [&](auto) -> int& { return b; })(v));
             }

--- a/test/variant/nonrecursive_match_auto.cpp
+++ b/test/variant/nonrecursive_match_auto.cpp
@@ -1,6 +1,6 @@
 #include "../test_utils.hpp"
 #include "../variant_test_utils.hpp"
-#include <scelta/match.hpp>
+#include <scelta/nonrecursive/match.hpp>
 
 // clang-format off
 struct a { int foo() { return 0; } };
@@ -58,7 +58,7 @@ TEST_MAIN()
         {
             {
                 auto v = make(a{});
-                scelta::match(
+                scelta::nonrecursive::match(
                     [](a x) {                return x.foo(); },
                     [](b x) { EXPECT(false); return x.bar(); },
                     [](c x) { EXPECT(false); return x.bar(); })(v);
@@ -83,19 +83,19 @@ TEST_MAIN()
                 * http://stackoverflow.com/questions/43982799
                 */
 
-                scelta::match(
+                scelta::nonrecursive::match(
                     [](a x)                         {                return x.foo(); },
                     [](auto x) -> decltype(x.bar()) { EXPECT(false); return x.bar(); })(v);
             }
 
             {
                 auto v = make(b{});
-                scelta::match(
+                scelta::nonrecursive::match(
                     [](a x) { EXPECT(false); return x.foo(); },
                     [](b x) {                return x.bar(); },
                     [](c x) { EXPECT(false); return x.bar(); })(v);
 
-                scelta::match(
+                scelta::nonrecursive::match(
                     [](a x)                         { EXPECT(false); return x.foo(); },
                     [](auto x) -> decltype(x.bar()) {                return x.bar(); })(v);
                 // TODO: match linearly?

--- a/test/variant/nonrecursive_match_multi.cpp
+++ b/test/variant/nonrecursive_match_multi.cpp
@@ -1,6 +1,6 @@
 #include "../test_utils.hpp"
 #include "../variant_test_utils.hpp"
-#include <scelta/match.hpp>
+#include <scelta/nonrecursive/match.hpp>
 
 struct a
 {
@@ -25,10 +25,10 @@ TEST_MAIN()
         [](auto make)                 //
         {
             {
-                auto f = scelta::match(     //
-                    [](a, a) { return 0; }, //
-                    [](a, b) { return 1; }, //
-                    [](b, b) { return 2; }, //
+                auto f = scelta::nonrecursive::match( //
+                    [](a, a) { return 0; },           //
+                    [](a, b) { return 1; },           //
+                    [](b, b) { return 2; },           //
                     [](b, a) { return 3; });
 
                 MAKE_AND_EXPECT(a, a, 0);

--- a/test/variant/visit.cpp
+++ b/test/variant/visit.cpp
@@ -39,5 +39,19 @@ TEST_MAIN()
                 auto v = make('c');
                 scelta::visit(f, v);
             }
+
+            {
+                int a;
+                int b;
+                auto f = scelta::overload(         //
+                    [&](int) -> int& { return a; }, //
+                    [&](auto) -> int& { return b; });
+
+                auto v0 = make(1);
+                EXPECT_EQ(&scelta::visit(f, v0), &a);
+
+                auto v1 = make('a');
+                EXPECT_EQ(&scelta::visit(f, v1), &b);
+            }
         });
 }

--- a/test/variant/visit.cpp
+++ b/test/variant/visit.cpp
@@ -1,6 +1,6 @@
 #include "../test_utils.hpp"
 #include "../variant_test_utils.hpp"
-#include <scelta/visitation.hpp>
+#include <scelta/nonrecursive/visit.hpp>
 
 TEST_MAIN()
 {
@@ -17,7 +17,7 @@ TEST_MAIN()
                     [](char) { EXPECT(false); });
 
                 auto v = make(1);
-                scelta::visit(f, v);
+                scelta::nonrecursive::visit(f, v);
             }
 
             {
@@ -27,7 +27,7 @@ TEST_MAIN()
                     [](char) { EXPECT(false); });
 
                 auto v = make(2.f);
-                scelta::visit(f, v);
+                scelta::nonrecursive::visit(f, v);
             }
 
             {
@@ -37,7 +37,7 @@ TEST_MAIN()
                     [](char x) { EXPECT_OP(x, ==, 'c'); });
 
                 auto v = make('c');
-                scelta::visit(f, v);
+                scelta::nonrecursive::visit(f, v);
             }
 
             {
@@ -48,10 +48,10 @@ TEST_MAIN()
                     [&](auto) -> int& { return b; });
 
                 auto v0 = make(1);
-                EXPECT_EQ(&scelta::visit(f, v0), &a);
+                EXPECT_EQ(&scelta::nonrecursive::visit(f, v0), &a);
 
                 auto v1 = make('a');
-                EXPECT_EQ(&scelta::visit(f, v1), &b);
+                EXPECT_EQ(&scelta::nonrecursive::visit(f, v1), &b);
             }
         });
 }

--- a/test/variant/visit_multi.cpp
+++ b/test/variant/visit_multi.cpp
@@ -1,6 +1,6 @@
 #include "../test_utils.hpp"
 #include "../variant_test_utils.hpp"
-#include <scelta/visitation.hpp>
+#include <scelta/nonrecursive/visit.hpp>
 
 struct a
 {
@@ -13,7 +13,7 @@ struct b
     {                                              \
         auto v0 = make(t0{});                      \
         auto v1 = make(t1{});                      \
-        EXPECT_EQ(scelta::visit(f, v0, v1), expc); \
+        EXPECT_EQ(scelta::nonrecursive::visit(f, v0, v1), expc); \
     }
 
 TEST_MAIN()

--- a/test/variant_test_utils.hpp
+++ b/test/variant_test_utils.hpp
@@ -74,11 +74,9 @@ namespace test
         f(TestCase<mpark::variant>{});
 #endif
 
-/* TODO: type_safe is currently broken
 #if defined(SCELTA_SUPPORT_VARIANT_TYPE_SAFE)
         f(TestCase<type_safe::variant>{});
 #endif
-*/
     }
 
     template <template <template <typename...> class> class TestCase,

--- a/test/variant_test_utils.hpp
+++ b/test/variant_test_utils.hpp
@@ -74,9 +74,11 @@ namespace test
         f(TestCase<mpark::variant>{});
 #endif
 
+/* TODO: type_safe is currently broken
 #if defined(SCELTA_SUPPORT_VARIANT_TYPE_SAFE)
         f(TestCase<type_safe::variant>{});
 #endif
+*/
     }
 
     template <template <template <typename...> class> class TestCase,


### PR DESCRIPTION
Added an homogeneous `scelta::match` statement that adapts to both non-recursive and recursive pattern matching. 

The idea is that this should be the "go-to `match` function", unless the user explicitly needs non-recursive/recursive `match`.

From the README:

> After defining recursive structures, *in place recursive visitation* is also possible. `scelta` provides two ways of performing recursive visitation:
> 
> * `scelta::match(/* base cases */)(/* recursive cases */)(/* visitables */)`
> 
>     This is an "homogeneous" `match` function that works for both non-recursive and recursive visitation. The first invocation always takes an arbitrary amount of *base cases*. If *recursive cases* are provided to the second invocation, then a third invocation with *visitables* is expected. Unless explicitly provided, **the return type is deduced from the base cases.**
> 
>     The *base cases* must have arity `N`, the *recursive cases* must have arity `N + 1`. `N` is the number of *visitables* that will be provided.
> 
> * `scelta::recursive::match</* return type */>(/* recursive cases */)(/* visitables */)`
> 
>     This version always requires an explicit return type and an arbitrary amount of *recursive cases* with arity `N + 1`, where `N` is the number of *visitables* that will be provided.
> 
> ```cpp
> int_tree t0{/*...*/};
> 
> scelta::match(
>     // Base case.
>     [](int x){ cout << x; }
> )(
>     // Recursive case.
>     [](auto recurse, int_tree_vector v){ for(auto x : v) recurse(v); }
> )(t0);
> 
> // ... or ...
> 
> scelta::recursive::match<return_type>(
>     // Base case.
>     [](auto, int x){ cout << x; },
> 
>     // Recursive case.
>     [](auto recurse, int_tree_vector v){ for(auto x : v) recurse(v); }
> )(t0);
> ```