### PR TITLE
Add support for TartanLlama's `tl::optional`

### DIFF
--- a/example/example_utils.hpp
+++ b/example/example_utils.hpp
@@ -37,6 +37,8 @@ namespace example
         ::boost::optional
 #elif defined(SCELTA_SUPPORT_OPTIONAL_TYPE_SAFE)
         ::type_safe::optional
+#elif defined(SCELTA_SUPPORT_OPTIONAL_TL)
+        ::tl::optional
 #else
 #error "No optional type available."
 #endif

--- a/include/scelta/support/optional.hpp
+++ b/include/scelta/support/optional.hpp
@@ -7,3 +7,4 @@
 #include "./optional/std.hpp"
 #include "./optional/boost.hpp"
 #include "./optional/type_safe.hpp"
+#include "./optional/tl.hpp"

--- a/include/scelta/support/optional/tl.hpp
+++ b/include/scelta/support/optional/tl.hpp
@@ -1,0 +1,27 @@
+// Copyright (c) 2017 Vittorio Romeo
+// MIT License |  https://opensource.org/licenses/MIT
+// http://vittorioromeo.info | vittorio.romeo@outlook.com
+
+#pragma once
+#ifndef SCELTA_SUPPORT_OPTIONAL_TL_DISABLE
+
+// clang-format off
+#if __has_include(<tl/optional.hpp>)
+// clang-format on
+
+#include "../../utils/optional_utils.hpp"
+#include "../../traits/adt/visit.hpp"
+#include <tl/optional.hpp>
+
+#define SCELTA_SUPPORT_OPTIONAL_TL 1
+
+namespace scelta::traits::adt
+{
+    template <typename T>
+    struct visit<::tl::optional<T>> : impl::visit_optional_t
+    {
+    };
+}
+
+#endif
+#endif

--- a/test/variant_test_utils.hpp
+++ b/test/variant_test_utils.hpp
@@ -94,6 +94,10 @@ namespace test
 #if defined(SCELTA_SUPPORT_OPTIONAL_TYPE_SAFE)
         f(TestCase<type_safe::optional>{});
 #endif
+
+#if defined(SCELTA_SUPPORT_OPTIONAL_TL)
+        f(TestCase<tl::optional>{});
+#endif
     }
 
     template <typename TAlternatives, typename TF>


### PR DESCRIPTION
This PR adds support for [`tl::optional`](https://github.com/TartanLlama/optional) to `scelta`. This excellent `optional` implementation provides useful continuations. E.g.

```cpp
tl::optional<image> get_cute_cat (const image& img) {
    return crop_to_cat(img)
           .and_then(add_bow_tie)
           .and_then(make_eyes_sparkle)
           .map(make_smaller)
           .map(add_rainbow);
}
```

`tl::optional` support is enabled if `__has_include(<tl/optional.hpp>)`. When enabled, the `SCELTA_SUPPORT_OPTIONAL_TL` is defined.

Automatic detection of `tl::optional` can be disabled by defining `SCELTA_SUPPORT_OPTIONAL_TL_DISABLE`.

