### PR TITLE
Add a target alias for the Scelta headers target.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,3 +42,7 @@ add_subdirectory(example)
 
 # Create header-only install target (automatically glob)
 vrm_cmake_header_only_install_glob("${SCELTA_INC_DIR}" "include")
+
+# Allow parent projects to depend on Scelta by adding
+# `scelta::headers` to the list of target_link_libraries.
+add_library( scelta::headers ALIAS HEADER_ONLY_TARGET )


### PR DESCRIPTION
This is the recommended practice in "modern CMake" style.
It will allow a parent project to depend on the Scelta
headers by adding the `scelta::headers` target into the
list of target_link_libraries.

Tested with CMake version 3.13.1.